### PR TITLE
Hackish removal ShiftKey for the OrderBy

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@
 
 **React Table v7** is mostly planned and I (@tannerlinsley) am looking for Patreon support to make it a reality. It will require a decent time commitment on my part to not only implement it, but also help people migrate and maintain it. If you would like to contribute to my Patreon goal for v7, [visit my Patreon and help me out!](https://patreon.com/tannerlinsley). Gold
 
+## Modified version (removed Shiftkey)
+When using column multisort, the user had to press the Shift button.
+This `hacked` version removes the Shift button for the multisort column by "emulating" it.
+
 ## Table of Contents
 
 - [Installation](#installation)

--- a/src/index.js
+++ b/src/index.js
@@ -336,7 +336,8 @@ export default class ReactTable extends Methods(Lifecycle(Component)) {
             maxWidth: _.asPx(maxWidth),
           }}
           toggleSort={e => {
-            if (isSortable) this.sortColumn(column, multiSort ? e.shiftKey : false)
+            // if (isSortable) this.sortColumn(column, multiSort ? e.shiftKey : false)
+            if (isSortable) this.sortColumn(column, true)
           }}
           {...rest}
         >


### PR DESCRIPTION
Removed ShiftKey button for the multisort column.
Now the user can easily use the multisort column and the ShiftKey is "simulated"